### PR TITLE
Task 도메인의 Entity 개발

### DIFF
--- a/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
@@ -1,4 +1,46 @@
 package com.todoapp.shared_todo.domain.task.entity;
 
-public class Task {
+import com.todoapp.shared_todo.domain.board.entity.Board;
+import com.todoapp.shared_todo.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Task extends BaseTimeEntity {
+
+    // 정적 팩토리 메서드
+    public static Task create(String content, Board board) {
+        Task task = new Task();
+        task.setContent(content);
+        task.setBoard(board);
+        return task;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "todo_id")
+    private Long taskId;
+
+    @Column(length = 100, nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TaskStatus status = TaskStatus.UNCHECKED;
+
+    // 소속 보드
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    // 상태 토글 메서드
+    public void toggleStatus() {
+        this.status = (this.status == TaskStatus.UNCHECKED)
+                ? TaskStatus.CHECKED
+                : TaskStatus.UNCHECKED;
+    }
 }
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/entity/TaskStatus.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/entity/TaskStatus.java
@@ -1,0 +1,6 @@
+package com.todoapp.shared_todo.domain.task.entity;
+
+public enum TaskStatus {
+    UNCHECKED,
+    CHECKED
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #24

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  - `Task` 엔티티 클래스 생성
    - `BaseTimeEntity` 상속으로 `created_at`, `updated_at` 자동 관리
    - 정적 팩토리 메서드 `create()` 구현으로 객체 생성 캡슐화
    - `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 적용으로 불변성 보장
  - `TaskStatus` enum 생성
    - `UNCHECKED`, `CHECKED` 상태 정의
    - `@Enumerated(EnumType.STRING)`으로 DB 저장
  - Board와의 연관관계 설정
    - `@ManyToOne(fetch = FetchType.LAZY)`로 Board와 다대일 관계 매핑
    - `@JoinColumn(name = "board_id")`로 외래키 설정
  - 비즈니스 로직 메서드
    - `toggleStatus()`: Task 완료 상태 토글 기능 구현
  - JPA 매핑
    - `@Column(name = "todo_id")`로 테이블 컬럼명 매핑
    - `content` 필드에 길이 제한(100자) 및 NOT NULL 제약조건 설정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
