### PR TITLE
Task도메인에 따른 Dto 및 Repository개발

### DIFF
--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskCreateRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskCreateRequest.java
@@ -1,0 +1,20 @@
+package com.todoapp.shared_todo.domain.task.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor      
+@AllArgsConstructor     
+@Builder                
+public class TaskCreateRequest {
+
+    @NotBlank(message = "Task 설명은 필수입니다.")
+    @Size(min = 1, message = "Task 설명은 최소 1자 이상이어야 합니다.")
+    private String description;
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskRequest.java
@@ -1,4 +1,0 @@
-package com.todoapp.shared_todo.domain.task.dto;
-
-public class TaskRequest {
-}

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
@@ -1,4 +1,18 @@
 package com.todoapp.shared_todo.domain.task.dto;
 
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder                
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 직렬화 대비
+@AllArgsConstructor(access = AccessLevel.PRIVATE)  // 빌더에서만 사용
 public class TaskResponse {
+
+    private Long id;
+    private String description;
+    private Boolean completed;
+    private LocalDateTime dueDate;
 }
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.todoapp.shared_todo.domain.task.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor      
+@AllArgsConstructor     
+@Builder                
+public class TaskUpdateRequest {
+
+    @NotBlank(message = "Task 설명은 필수입니다.")
+    @Size(min = 1, message = "Task 설명은 최소 1자 이상이어야 합니다.")
+    private String description;
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
@@ -1,0 +1,16 @@
+package com.todoapp.shared_todo.domain.task.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor      
+@AllArgsConstructor     
+@Builder                
+public class TaskUpdateStatusRequest {
+
+    private Boolean completed;
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
@@ -5,6 +5,8 @@ import com.todoapp.shared_todo.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @Entity
@@ -12,35 +14,35 @@ import lombok.*;
 public class Task extends BaseTimeEntity {
 
     // 정적 팩토리 메서드
-    public static Task create(String content, Board board) {
+    public static Task create(String description, Board board) {
         Task task = new Task();
-        task.setContent(content);
+        task.setDescription(description);
         task.setBoard(board);
+        task.setCompleted(false);
         return task;
     }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "todo_id")
-    private Long taskId;
+    private Long id;
 
-    @Column(length = 100, nullable = false)
-    private String content;
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private TaskStatus status = TaskStatus.UNCHECKED;
+    private Boolean completed = false;
+
+    @Column(name = "due_date")
+    private LocalDateTime dueDate;
 
     // 소속 보드
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
-    // 상태 토글 메서드
-    public void toggleStatus() {
-        this.status = (this.status == TaskStatus.UNCHECKED)
-                ? TaskStatus.CHECKED
-                : TaskStatus.UNCHECKED;
+    // 완료 상태 토글 메서드
+    public void toggleCompleted() {
+        this.completed = !this.completed;
     }
 }
 

--- a/src/main/java/com/todoapp/shared_todo/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/repository/TaskRepository.java
@@ -1,4 +1,22 @@
 package com.todoapp.shared_todo.domain.task.repository;
 
-public class TaskRepository {
+import com.todoapp.shared_todo.domain.board.entity.Board;
+import com.todoapp.shared_todo.domain.task.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    // 보드별 task 리스트 조회
+    List<Task> findByBoard(Board board);
+
+    // 보드 ID로 task 리스트 조회
+    List<Task> findByBoardId(Long boardId);
+
+    // task ID와 보드로 조회 (권한 확인용)
+    Optional<Task> findByIdAndBoard(Long id, Board board);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
>#26

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Task Repository 구현
  - `TaskRepository` 인터페이스 생성
    - `JpaRepository<Task, Long>` 상속
    - `findByBoard()`: 보드별 Task 리스트 조회 메서드
    - `findByBoardId()`: 보드 ID로 Task 리스트 조회 메서드
    - `findByIdAndBoard()`: Task ID와 보드로 조회 (권한 확인용)

- Task DTO 구현
  - `TaskCreateRequest`: Task 생성 요청 DTO
    - `description` 필드 (ERD의 description 반영)
    - `@NotBlank`, `@Size(min = 1)` 유효성 검증 적용
    - TEXT 타입을 고려한 길이 제한 제거
  - `TaskResponse`: Task 응답 DTO
    - `@Builder` 패턴 적용, 불변 객체 설계
    - `id`, `description`, `completed`, `dueDate` 필드 포함
  - `TaskUpdateRequest`: Task 내용 수정 요청 DTO
    - `description` 필드 (ERD의 description 반영)
    - `@NotBlank`, `@Size(min = 1)` 유효성 검증 적용
  - `TaskUpdateStatusRequest`: Task 상태 수정 요청 DTO
    - `completed` Boolean 타입으로 상태 변경 (ERD의 completed 필드 반영)

### 스크린샷 (선택)

<img width="204" height="182" alt="image" src="https://github.com/user-attachments/assets/718dca4c-0355-4e32-9478-ebac8ee6cf4b" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
