### PR TITLE
Board 도메인에 따른 entity 및 repository 개발

### DIFF
--- a/src/main/java/com/todoapp/shared_todo/domain/board/entity/Board.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/board/entity/Board.java
@@ -1,4 +1,45 @@
 package com.todoapp.shared_todo.domain.board.entity;
 
-public class Board {
+import com.todoapp.shared_todo.domain.task.entity.Task;
+import com.todoapp.shared_todo.domain.user.entity.User;
+import com.todoapp.shared_todo.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Board extends BaseTimeEntity {
+
+    // 정적 팩토리 메서드
+    public static Board create(String title, User author) {
+        Board board = new Board();
+        board.setTitle(title);
+        board.setAuthor(author);
+        board.setCompletionRate(0.0f);
+        return board;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    // 보드 소유자 (최초 생성자)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "completion_rate")
+    private Float completionRate = 0.0f;
+
+    // 이 보드에 속한 Task 리스트들
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Task> tasks = new ArrayList<>();
 }

--- a/src/main/java/com/todoapp/shared_todo/domain/board/entity/Board.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/board/entity/Board.java
@@ -1,5 +1,6 @@
 package com.todoapp.shared_todo.domain.board.entity;
 
+import com.todoapp.shared_todo.domain.boardMember.entity.BoardMember;
 import com.todoapp.shared_todo.domain.task.entity.Task;
 import com.todoapp.shared_todo.domain.user.entity.User;
 import com.todoapp.shared_todo.global.common.BaseTimeEntity;
@@ -42,4 +43,8 @@ public class Board extends BaseTimeEntity {
     // 이 보드에 속한 Task 리스트들
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Task> tasks = new ArrayList<>();
+
+    // 이 보드의 멤버들
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<BoardMember> members = new ArrayList<>();
 }

--- a/src/main/java/com/todoapp/shared_todo/domain/boardMember/entity/BoardMember.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/boardMember/entity/BoardMember.java
@@ -1,0 +1,54 @@
+package com.todoapp.shared_todo.domain.boardMember.entity;
+
+import com.todoapp.shared_todo.domain.board.entity.Board;
+import com.todoapp.shared_todo.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "board_member", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"board_id", "user_id"})
+})
+public class BoardMember {
+
+    // 정적 팩토리 메서드
+    public static BoardMember create(Board board, User user, String role) {
+        BoardMember boardMember = new BoardMember();
+        boardMember.setBoard(board);
+        boardMember.setUser(user);
+        boardMember.setRole(role);
+        return boardMember;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 소속 보드
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    // 보드 멤버 (유저)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(length = 20, nullable = false)
+    private String role = "OWNER";
+
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @PrePersist
+    @SuppressWarnings("unused") // JPA가 런타임에 자동으로 호출하는 메서드
+    protected void onCreate() {
+        joinedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/boardMember/repository/BoardMemberRepository.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/boardMember/repository/BoardMemberRepository.java
@@ -1,0 +1,30 @@
+package com.todoapp.shared_todo.domain.boardMember.repository;
+
+import com.todoapp.shared_todo.domain.board.entity.Board;
+import com.todoapp.shared_todo.domain.boardMember.entity.BoardMember;
+import com.todoapp.shared_todo.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BoardMemberRepository extends JpaRepository<BoardMember, Long> {
+
+    // 보드와 유저로 BoardMember 조회
+    Optional<BoardMember> findByBoardAndUser(Board board, User user);
+
+    // 보드 ID와 유저 ID로 BoardMember 조회
+    Optional<BoardMember> findByBoardIdAndUserId(Long boardId, Long userId);
+
+    // 보드의 모든 멤버 조회
+    List<BoardMember> findByBoard(Board board);
+
+    // 유저가 참여한 모든 보드 조회
+    List<BoardMember> findByUser(User user);
+
+    // 보드 ID로 모든 멤버 조회
+    List<BoardMember> findByBoardId(Long boardId);
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskCreateRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskCreateRequest.java
@@ -1,0 +1,20 @@
+package com.todoapp.shared_todo.domain.task.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor      
+@AllArgsConstructor     
+@Builder                
+public class TaskCreateRequest {
+
+    @NotBlank(message = "Task 설명은 필수입니다.")
+    @Size(min = 1, message = "Task 설명은 최소 1자 이상이어야 합니다.")
+    private String description;
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskRequest.java
@@ -1,4 +1,0 @@
-package com.todoapp.shared_todo.domain.task.dto;
-
-public class TaskRequest {
-}

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
@@ -1,4 +1,18 @@
 package com.todoapp.shared_todo.domain.task.dto;
 
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder                
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 직렬화 대비
+@AllArgsConstructor(access = AccessLevel.PRIVATE)  // 빌더에서만 사용
 public class TaskResponse {
+
+    private Long id;
+    private String description;
+    private Boolean completed;
+    private LocalDateTime dueDate;
 }
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.todoapp.shared_todo.domain.task.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor      
+@AllArgsConstructor     
+@Builder                
+public class TaskUpdateRequest {
+
+    @NotBlank(message = "Task 설명은 필수입니다.")
+    @Size(min = 1, message = "Task 설명은 최소 1자 이상이어야 합니다.")
+    private String description;
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
@@ -1,0 +1,16 @@
+package com.todoapp.shared_todo.domain.task.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor      
+@AllArgsConstructor     
+@Builder                
+public class TaskUpdateStatusRequest {
+
+    private Boolean completed;
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
@@ -5,6 +5,8 @@ import com.todoapp.shared_todo.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @Entity
@@ -12,35 +14,35 @@ import lombok.*;
 public class Task extends BaseTimeEntity {
 
     // 정적 팩토리 메서드
-    public static Task create(String content, Board board) {
+    public static Task create(String description, Board board) {
         Task task = new Task();
-        task.setContent(content);
+        task.setDescription(description);
         task.setBoard(board);
+        task.setCompleted(false);
         return task;
     }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "todo_id")
-    private Long taskId;
+    private Long id;
 
-    @Column(length = 100, nullable = false)
-    private String content;
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private TaskStatus status = TaskStatus.UNCHECKED;
+    private Boolean completed = false;
+
+    @Column(name = "due_date")
+    private LocalDateTime dueDate;
 
     // 소속 보드
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
-    // 상태 토글 메서드
-    public void toggleStatus() {
-        this.status = (this.status == TaskStatus.UNCHECKED)
-                ? TaskStatus.CHECKED
-                : TaskStatus.UNCHECKED;
+    // 완료 상태 토글 메서드
+    public void toggleCompleted() {
+        this.completed = !this.completed;
     }
 }
 

--- a/src/main/java/com/todoapp/shared_todo/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/repository/TaskRepository.java
@@ -1,4 +1,22 @@
 package com.todoapp.shared_todo.domain.task.repository;
 
-public class TaskRepository {
+import com.todoapp.shared_todo.domain.board.entity.Board;
+import com.todoapp.shared_todo.domain.task.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    // 보드별 task 리스트 조회
+    List<Task> findByBoard(Board board);
+
+    // 보드 ID로 task 리스트 조회
+    List<Task> findByBoardId(Long boardId);
+
+    // task ID와 보드로 조회 (권한 확인용)
+    Optional<Task> findByIdAndBoard(Long id, Board board);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #33

## 📝 작업 내용
> Board 엔티티 구현

- Board 엔티티
  - ERD 설계에 따른 Board 엔티티 구현
  - `title` 필드: 최대 50자, 필수 입력
  - `author` 필드: 보드 소유자 (User와 ManyToOne 관계)
  - `completionRate` 필드: 완료율 (기본값 0.0f)
  - `tasks` 필드: 보드에 속한 Task 리스트 (OneToMany)
  - `members` 필드: 보드 멤버 리스트 (OneToMany)
  - 정적 팩토리 메서드 `create()` 구현
  - BaseTimeEntity 상속으로 생성/수정 시간 자동 관리

### 스크린샷 (선택)

<img width="135" height="43" alt="image" src="https://github.com/user-attachments/assets/513fc492-cac7-4ee8-9130-b0ffcaf2aba0" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
