### PR TITLE
BoardMember 도메인에 따른 entity 및 repository 개발

### DIFF
--- a/src/main/java/com/todoapp/shared_todo/domain/board/entity/Board.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/board/entity/Board.java
@@ -1,4 +1,45 @@
 package com.todoapp.shared_todo.domain.board.entity;
 
-public class Board {
+import com.todoapp.shared_todo.domain.task.entity.Task;
+import com.todoapp.shared_todo.domain.user.entity.User;
+import com.todoapp.shared_todo.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Board extends BaseTimeEntity {
+
+    // 정적 팩토리 메서드
+    public static Board create(String title, User author) {
+        Board board = new Board();
+        board.setTitle(title);
+        board.setAuthor(author);
+        board.setCompletionRate(0.0f);
+        return board;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    // 보드 소유자 (최초 생성자)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "completion_rate")
+    private Float completionRate = 0.0f;
+
+    // 이 보드에 속한 Task 리스트들
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Task> tasks = new ArrayList<>();
 }

--- a/src/main/java/com/todoapp/shared_todo/domain/boardMember/entity/BoardMember.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/boardMember/entity/BoardMember.java
@@ -1,0 +1,54 @@
+package com.todoapp.shared_todo.domain.boardMember.entity;
+
+import com.todoapp.shared_todo.domain.board.entity.Board;
+import com.todoapp.shared_todo.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "board_member", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"board_id", "user_id"})
+})
+public class BoardMember {
+
+    // 정적 팩토리 메서드
+    public static BoardMember create(Board board, User user, String role) {
+        BoardMember boardMember = new BoardMember();
+        boardMember.setBoard(board);
+        boardMember.setUser(user);
+        boardMember.setRole(role);
+        return boardMember;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 소속 보드
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    // 보드 멤버 (유저)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(length = 20, nullable = false)
+    private String role = "OWNER";
+
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @PrePersist
+    @SuppressWarnings("unused") // JPA가 런타임에 자동으로 호출하는 메서드
+    protected void onCreate() {
+        joinedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/boardMember/repository/BoardMemberRepository.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/boardMember/repository/BoardMemberRepository.java
@@ -1,0 +1,30 @@
+package com.todoapp.shared_todo.domain.boardMember.repository;
+
+import com.todoapp.shared_todo.domain.board.entity.Board;
+import com.todoapp.shared_todo.domain.boardMember.entity.BoardMember;
+import com.todoapp.shared_todo.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BoardMemberRepository extends JpaRepository<BoardMember, Long> {
+
+    // 보드와 유저로 BoardMember 조회
+    Optional<BoardMember> findByBoardAndUser(Board board, User user);
+
+    // 보드 ID와 유저 ID로 BoardMember 조회
+    Optional<BoardMember> findByBoardIdAndUserId(Long boardId, Long userId);
+
+    // 보드의 모든 멤버 조회
+    List<BoardMember> findByBoard(Board board);
+
+    // 유저가 참여한 모든 보드 조회
+    List<BoardMember> findByUser(User user);
+
+    // 보드 ID로 모든 멤버 조회
+    List<BoardMember> findByBoardId(Long boardId);
+}
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #35 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- BoardMember 엔티티 구현
  - 보드와 사용자 간의 관계를 표현하는 중간 엔티티
  - `board_id`와 `user_id` 복합 유니크 제약조건
  - 역할(role) 필드: 기본값 "OWNER"
  - `joinedAt` 필드: `@PrePersist`로 자동 생성 시간 설정
  - 정적 팩토리 메서드 `create()` 구현
 
- BoardMemberRepository 구현
  - `findByBoardAndUser`: 보드와 유저로 조회
  - `findByBoardIdAndUserId`: 보드 ID와 유저 ID로 조회

- ERD 설계에 따른 `board_member` 테이블 구조 반영
- 보드 공유 기능을 위한 기반 구조 구축
- BoardService에서 보드 생성 시 소유자 자동 등록 기능 연동

### 스크린샷 (선택)

<img width="222" height="117" alt="image" src="https://github.com/user-attachments/assets/f966cc1f-c8a4-41db-af9a-612267383a9d" />