### PR TITLE
BoardMemberService, BoardMemberController 추가 / BoardMemberRepository 수정

### DIFF
--- a/src/main/java/com/todoapp/shared_todo/domain/boardMember/controller/BoardMemberController.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/boardMember/controller/BoardMemberController.java
@@ -1,0 +1,56 @@
+package com.todoapp.shared_todo.domain.boardMember.controller;
+
+import com.todoapp.shared_todo.domain.boardMember.dto.BoardMemberResponse;
+import com.todoapp.shared_todo.domain.boardMember.entity.BoardMemberRole;
+import com.todoapp.shared_todo.domain.boardMember.service.BoardMemberService;
+import com.todoapp.shared_todo.global.dto.SimpleStatusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/board")
+@RequiredArgsConstructor
+@SuppressWarnings("unused") // Spring이 런타임에 자동으로 등록하고 사용하는 Controller
+public class BoardMemberController {
+
+    private final BoardMemberService boardMemberService;
+
+    /**
+     * 보드 멤버 목록 조회
+     */
+    @GetMapping("/{boardId}/members")
+    public ResponseEntity<List<BoardMemberResponse>> getBoardMembers(
+            @PathVariable Long boardId,
+            @RequestParam Long userId, // TODO: JWT 인증 후 SecurityContext에서 가져오도록 변경
+            @RequestParam(required = false) BoardMemberRole role) { // 역할 필터 (선택적)
+        List<BoardMemberResponse> responses = boardMemberService.getBoardMembers(boardId, userId, role);
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 보드 멤버 삭제 (OWNER만 가능, 자기 자신 제거 불가)
+     */
+    @PutMapping("/{boardId}/members/{userId}")
+    public ResponseEntity<SimpleStatusResponse> deleteBoardMember(
+            @PathVariable Long boardId,
+            @PathVariable Long userId, // 삭제할 멤버의 userId
+            @RequestParam Long ownerId) { // TODO: JWT 인증 후 SecurityContext에서 가져오도록 변경
+        boardMemberService.deleteBoardMember(boardId, ownerId, userId);
+        return ResponseEntity.ok(new SimpleStatusResponse(true));
+    }
+
+    /**
+     * 보드 멤버 나가기 (GUEST만 가능)
+     */
+    @PutMapping("/{boardId}/members/me/leave")
+    public ResponseEntity<SimpleStatusResponse> leaveBoard(
+            @PathVariable Long boardId,
+            @RequestParam Long userId) { // TODO: JWT 인증 후 SecurityContext에서 가져오도록 변경
+        boardMemberService.leaveBoard(boardId, userId);
+        return ResponseEntity.ok(new SimpleStatusResponse(true));
+    }
+}
+

--- a/src/main/java/com/todoapp/shared_todo/domain/boardMember/repository/BoardMemberRepository.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/boardMember/repository/BoardMemberRepository.java
@@ -1,6 +1,7 @@
 package com.todoapp.shared_todo.domain.boardMember.repository;
 
 import com.todoapp.shared_todo.domain.boardMember.entity.BoardMember;
+import com.todoapp.shared_todo.domain.boardMember.entity.BoardMemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,6 +16,12 @@ public interface BoardMemberRepository extends JpaRepository<BoardMember, Long> 
      * - 보드 멤버 목록 API에서 사용
      */
     List<BoardMember> findByBoardId(Long boardId);
+
+    /**
+     * 특정 보드에 특정 역할을 가진 멤버 조회
+     * - 역할 필터링용
+     */
+    List<BoardMember> findByBoardIdAndRole(Long boardId, BoardMemberRole role);
 
     /**
      * 특정 보드에 특정 유저가 멤버로 존재하는지 조회

--- a/src/main/java/com/todoapp/shared_todo/domain/boardMember/service/BoardMemberService.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/boardMember/service/BoardMemberService.java
@@ -1,0 +1,105 @@
+package com.todoapp.shared_todo.domain.boardMember.service;
+
+import com.todoapp.shared_todo.domain.board.repository.BoardRepository;
+import com.todoapp.shared_todo.domain.boardMember.dto.BoardMemberResponse;
+import com.todoapp.shared_todo.domain.boardMember.entity.BoardMember;
+import com.todoapp.shared_todo.domain.boardMember.entity.BoardMemberRole;
+import com.todoapp.shared_todo.domain.boardMember.repository.BoardMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardMemberService {
+
+    private final BoardMemberRepository boardMemberRepository;
+    private final BoardRepository boardRepository;
+
+    /**
+     * 보드 멤버 목록 조회
+     */
+    public List<BoardMemberResponse> getBoardMembers(Long boardId, Long userId, BoardMemberRole role) {
+        // 보드 존재 확인
+        boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("보드를 찾을 수 없습니다."));
+
+        // 요청한 사용자가 보드 멤버인지 확인
+        boardMemberRepository.findByBoardIdAndUserId(boardId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("보드에 접근할 권한이 없습니다."));
+
+        // 역할 필터링이 있는 경우 해당 역할의 멤버만 조회, 없으면 전체 조회
+        List<BoardMember> members;
+        if (role != null) {
+            members = boardMemberRepository.findByBoardIdAndRole(boardId, role);
+        } else {
+            members = boardMemberRepository.findByBoardId(boardId);
+        }
+
+        return members.stream()
+                .map(member -> new BoardMemberResponse(
+                        member.getUser().getId(),
+                        member.getUser().getNickname(),
+                        member.getRole()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 보드 멤버 삭제 (OWNER만 가능, 자기 자신 제거 불가)
+     */
+    @Transactional
+    public void deleteBoardMember(Long boardId, Long ownerId, Long memberUserId) {
+        // 보드 존재 확인
+        boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("보드를 찾을 수 없습니다."));
+
+        // 요청자가 OWNER인지 확인
+        BoardMember ownerMember = boardMemberRepository.findByBoardIdAndUserId(boardId, ownerId)
+                .orElseThrow(() -> new IllegalArgumentException("보드에 접근할 권한이 없습니다."));
+
+        if (ownerMember.getRole() != BoardMemberRole.OWNER) {
+            throw new IllegalArgumentException("보드 멤버를 삭제할 권한이 없습니다. OWNER만 가능합니다.");
+        }
+
+        // 자기 자신 제거 불가
+        if (ownerId.equals(memberUserId)) {
+            throw new IllegalArgumentException("자기 자신은 제거할 수 없습니다.");
+        }
+
+        // 삭제할 멤버 존재 확인
+        if (!boardMemberRepository.existsByBoardIdAndUserId(boardId, memberUserId)) {
+            throw new IllegalArgumentException("삭제할 멤버를 찾을 수 없습니다.");
+        }
+
+        // 멤버 삭제
+        boardMemberRepository.deleteByBoardIdAndUserId(boardId, memberUserId);
+    }
+
+    /**
+     * 보드 멤버 나가기 (GUEST만 가능)
+     */
+    @Transactional
+    public void leaveBoard(Long boardId, Long userId) {
+        // 보드 존재 확인
+        boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("보드를 찾을 수 없습니다."));
+
+        // 사용자가 보드 멤버인지 확인
+        BoardMember member = boardMemberRepository.findByBoardIdAndUserId(boardId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("보드 멤버를 찾을 수 없습니다."));
+
+        // GUEST만 나가기 가능
+        if (member.getRole() != BoardMemberRole.GUEST) {
+            throw new IllegalArgumentException("GUEST만 보드를 나갈 수 있습니다.");
+        }
+
+        // 멤버 삭제
+        boardMemberRepository.deleteByBoardIdAndUserId(boardId, userId);
+    }
+}
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#52

## 📝 작업 내용

### BoardMemberRepository
역할 필터링용 특정 보드에 특정 역할을 가진 멤버 조회 추가

### API 개발
- 보드 멤버 목록 조회
- 보드 멤버 삭제 (OWNER만 가능, 자기 자신 제거 불가)
- 보드 멤버 나가기 (GUEST만 가능)

### 스크린샷 (선택)
<img width="756" height="124" alt="스크린샷 2025-12-28 오후 4 35 25" src="https://github.com/user-attachments/assets/25b0b61f-cd1b-42ee-aa4f-0a83da984c10" />

## 💬 리뷰 요구사항(선택)
Repository 추가 수정 부분
