### PR TITLE
Task 상태 Enum 리팩토링

### DIFF
--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
@@ -13,7 +13,6 @@ public class TaskResponse {
 
     private Long id;
     private String description;
-    // 기존 코드: private Boolean completed;
     private TaskStatus status;
     private LocalDateTime dueDate;
 }

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskResponse.java
@@ -1,5 +1,6 @@
 package com.todoapp.shared_todo.domain.task.dto;
 
+import com.todoapp.shared_todo.domain.task.entity.TaskStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -12,7 +13,8 @@ public class TaskResponse {
 
     private Long id;
     private String description;
-    private Boolean completed;
+    // 기존 코드: private Boolean completed;
+    private TaskStatus status;
     private LocalDateTime dueDate;
 }
 

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
@@ -1,5 +1,6 @@
 package com.todoapp.shared_todo.domain.task.dto;
 
+import com.todoapp.shared_todo.domain.task.entity.TaskStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder                
 public class TaskUpdateStatusRequest {
 
-    private Boolean completed;
+    // 기존 코드: private Boolean completed;
+    private TaskStatus status;
 }
 

--- a/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/dto/TaskUpdateStatusRequest.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @Builder                
 public class TaskUpdateStatusRequest {
 
-    // 기존 코드: private Boolean completed;
     private TaskStatus status;
 }
 

--- a/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
@@ -18,8 +18,9 @@ public class Task extends BaseTimeEntity {
         Task task = new Task();
         task.setDescription(description);
         task.setBoard(board);
-        task.setCompleted(false);
+        task.setStatus(TaskStatus.UNCHECKED);
         task.setDueDate(dueDate);
+        // 기존 코드: task.setCompleted(false);
         return task;
     }
 
@@ -30,8 +31,12 @@ public class Task extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
 
+    // 기존 코드: @Column(nullable = false)
+    // 기존 코드: private Boolean completed = false;
+
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Boolean completed = false;
+    private TaskStatus status = TaskStatus.UNCHECKED;
 
     @Column(name = "due_date")
     private LocalDateTime dueDate;
@@ -42,8 +47,16 @@ public class Task extends BaseTimeEntity {
     private Board board;
 
     // 완료 상태 토글 메서드
-    public void toggleCompleted() {
-        this.completed = !this.completed;
+    public void toggleStatus() {
+        if (this.status == TaskStatus.UNCHECKED) {
+            this.status = TaskStatus.CHECKED;
+        } else {
+            this.status = TaskStatus.UNCHECKED;
+        }
     }
+
+    // 기존 코드: public void toggleCompleted() {
+    // 기존 코드:     this.completed = !this.completed;
+    // 기존 코드: }
 }
 

--- a/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/entity/Task.java
@@ -20,7 +20,6 @@ public class Task extends BaseTimeEntity {
         task.setBoard(board);
         task.setStatus(TaskStatus.UNCHECKED);
         task.setDueDate(dueDate);
-        // 기존 코드: task.setCompleted(false);
         return task;
     }
 
@@ -31,8 +30,6 @@ public class Task extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
 
-    // 기존 코드: @Column(nullable = false)
-    // 기존 코드: private Boolean completed = false;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -55,8 +52,6 @@ public class Task extends BaseTimeEntity {
         }
     }
 
-    // 기존 코드: public void toggleCompleted() {
-    // 기존 코드:     this.completed = !this.completed;
-    // 기존 코드: }
+
 }
 

--- a/src/main/java/com/todoapp/shared_todo/domain/task/entity/TaskStatus.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/entity/TaskStatus.java
@@ -4,3 +4,4 @@ public enum TaskStatus {
     UNCHECKED,
     CHECKED
 }
+

--- a/src/main/java/com/todoapp/shared_todo/domain/task/service/TaskService.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/service/TaskService.java
@@ -119,14 +119,12 @@ public class TaskService {
         Task task = validateTaskAndBoardAccess(boardId, taskId, userId);
 
         task.toggleStatus();
-        // 기존 코드: task.toggleCompleted();
         Task updatedTask = taskRepository.save(task);
 
         return TaskResponse.builder()
                 .id(updatedTask.getId())
                 .description(updatedTask.getDescription())
                 .status(updatedTask.getStatus())
-                // 기존 코드: .completed(updatedTask.getCompleted())
                 .dueDate(updatedTask.getDueDate())
                 .build();
     }

--- a/src/main/java/com/todoapp/shared_todo/domain/task/service/TaskService.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/service/TaskService.java
@@ -46,7 +46,6 @@ public class TaskService {
                 .id(savedTask.getId())
                 .description(savedTask.getDescription())
                 .status(savedTask.getStatus())
-                // 기존 코드: .completed(savedTask.getCompleted())
                 .dueDate(savedTask.getDueDate())
                 .build();
     }
@@ -71,7 +70,6 @@ public class TaskService {
                         .id(task.getId())
                         .description(task.getDescription())
                         .status(task.getStatus())
-                        // 기존 코드: .completed(task.getCompleted())
                         .dueDate(task.getDueDate())
                         .build())
                 .collect(Collectors.toList());
@@ -88,7 +86,6 @@ public class TaskService {
                 .id(task.getId())
                 .description(task.getDescription())
                 .status(task.getStatus())
-                // 기존 코드: .completed(task.getCompleted())
                 .dueDate(task.getDueDate())
                 .build();
     }
@@ -109,7 +106,6 @@ public class TaskService {
                 .id(updatedTask.getId())
                 .description(updatedTask.getDescription())
                 .status(updatedTask.getStatus())
-                // 기존 코드: .completed(updatedTask.getCompleted())
                 .dueDate(updatedTask.getDueDate())
                 .build();
     }
@@ -144,14 +140,12 @@ public class TaskService {
         Task task = validateTaskAndBoardAccess(boardId, taskId, userId);
 
         task.setStatus(request.getStatus());
-        // 기존 코드: task.setCompleted(request.getCompleted());
         Task updatedTask = taskRepository.save(task);
 
         return TaskResponse.builder()
                 .id(updatedTask.getId())
                 .description(updatedTask.getDescription())
                 .status(updatedTask.getStatus())
-                // 기존 코드: .completed(updatedTask.getCompleted())
                 .dueDate(updatedTask.getDueDate())
                 .build();
     }

--- a/src/main/java/com/todoapp/shared_todo/domain/task/service/TaskService.java
+++ b/src/main/java/com/todoapp/shared_todo/domain/task/service/TaskService.java
@@ -7,6 +7,7 @@ import com.todoapp.shared_todo.domain.task.dto.TaskResponse;
 import com.todoapp.shared_todo.domain.task.dto.TaskUpdateRequest;
 import com.todoapp.shared_todo.domain.task.dto.TaskUpdateStatusRequest;
 import com.todoapp.shared_todo.domain.task.entity.Task;
+import com.todoapp.shared_todo.domain.task.entity.TaskStatus;
 import com.todoapp.shared_todo.domain.task.repository.TaskRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,8 @@ public class TaskService {
         return TaskResponse.builder()
                 .id(savedTask.getId())
                 .description(savedTask.getDescription())
-                .completed(savedTask.getCompleted())
+                .status(savedTask.getStatus())
+                // 기존 코드: .completed(savedTask.getCompleted())
                 .dueDate(savedTask.getDueDate())
                 .build();
     }
@@ -68,7 +70,8 @@ public class TaskService {
                 .map(task -> TaskResponse.builder()
                         .id(task.getId())
                         .description(task.getDescription())
-                        .completed(task.getCompleted())
+                        .status(task.getStatus())
+                        // 기존 코드: .completed(task.getCompleted())
                         .dueDate(task.getDueDate())
                         .build())
                 .collect(Collectors.toList());
@@ -84,7 +87,8 @@ public class TaskService {
         return TaskResponse.builder()
                 .id(task.getId())
                 .description(task.getDescription())
-                .completed(task.getCompleted())
+                .status(task.getStatus())
+                // 기존 코드: .completed(task.getCompleted())
                 .dueDate(task.getDueDate())
                 .build();
     }
@@ -104,7 +108,8 @@ public class TaskService {
         return TaskResponse.builder()
                 .id(updatedTask.getId())
                 .description(updatedTask.getDescription())
-                .completed(updatedTask.getCompleted())
+                .status(updatedTask.getStatus())
+                // 기존 코드: .completed(updatedTask.getCompleted())
                 .dueDate(updatedTask.getDueDate())
                 .build();
     }
@@ -117,13 +122,15 @@ public class TaskService {
     public TaskResponse toggleTaskStatus(Long boardId, Long taskId, Long userId) {
         Task task = validateTaskAndBoardAccess(boardId, taskId, userId);
 
-        task.toggleCompleted();
+        task.toggleStatus();
+        // 기존 코드: task.toggleCompleted();
         Task updatedTask = taskRepository.save(task);
 
         return TaskResponse.builder()
                 .id(updatedTask.getId())
                 .description(updatedTask.getDescription())
-                .completed(updatedTask.getCompleted())
+                .status(updatedTask.getStatus())
+                // 기존 코드: .completed(updatedTask.getCompleted())
                 .dueDate(updatedTask.getDueDate())
                 .build();
     }
@@ -136,13 +143,15 @@ public class TaskService {
     public TaskResponse updateTaskStatus(Long boardId, Long taskId, Long userId, @Valid TaskUpdateStatusRequest request) {
         Task task = validateTaskAndBoardAccess(boardId, taskId, userId);
 
-        task.setCompleted(request.getCompleted());
+        task.setStatus(request.getStatus());
+        // 기존 코드: task.setCompleted(request.getCompleted());
         Task updatedTask = taskRepository.save(task);
 
         return TaskResponse.builder()
                 .id(updatedTask.getId())
                 .description(updatedTask.getDescription())
-                .completed(updatedTask.getCompleted())
+                .status(updatedTask.getStatus())
+                // 기존 코드: .completed(updatedTask.getCompleted())
                 .dueDate(updatedTask.getDueDate())
                 .build();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #67 
## 📝 작업 내용

### Task 엔티티 리팩토링

- **Task 엔티티**
  - `completed` Boolean 필드를 `status` TaskStatus enum 필드로 변경
  - `@Enumerated(EnumType.STRING)` 어노테이션 추가하여 DB에 문자열로 저장
  - `toggleCompleted()` 메서드를 `toggleStatus()`로 변경
  - 기존 코드는 주석 처리하여 보존

- **TaskResponse DTO**
  - `completed` Boolean 필드를 `status` TaskStatus enum 필드로 변경
  - 기존 코드 주석 처리

- **TaskUpdateStatusRequest DTO**
  - `completed` Boolean 필드를 `status` TaskStatus enum 필드로 변경
  - 기존 코드 주석 처리

- **TaskService**
  - 모든 `getCompleted()`, `setCompleted()` 호출을 `getStatus()`, `setStatus()`로 변경
  - `toggleCompleted()` 호출을 `toggleStatus()`로 변경
  - 기존 코드 주석 처리

### 변경 이유

- TaskStatus enum이 이미 정의되어 있었으나 사용되지 않던 문제 해결
- Boolean 타입 대신 enum 사용으로 타입 안정성 향상
- 향후 상태 확장 시 유연성 확보 (예: UNCHECKED, CHECKED 외 추가 상태)

### 주요 변경 사항

```java
// 변경 전
private Boolean completed = false;
public void toggleCompleted() {
    this.completed = !this.completed;
}

// 변경 후
@Enumerated(EnumType.STRING)
@Column(nullable = false)
private TaskStatus status = TaskStatus.UNCHECKED;

public void toggleStatus() {
    if (this.status == TaskStatus.UNCHECKED) {
        this.status = TaskStatus.CHECKED;
    } else {
        this.status = TaskStatus.UNCHECKED;
    }
}
```

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> TaskStatus enum 사용이 적절한지 확인 부탁드립니다
> 기존 코드 주석 처리 방식이 적절한지 확인 부탁드립니다
> DTO와 Service 계층의 변경사항이 일관성 있게 적용되었는지 확인 부탁드립니다
